### PR TITLE
Use `subprocess.check_call` for STAR calls

### DIFF
--- a/scripts/mode1_alignment.py
+++ b/scripts/mode1_alignment.py
@@ -44,10 +44,10 @@ def alignment_func(out_dir,group,aln_dir,mate1,mate2):
     print(str(clock) + '\t' + "Performing alignment")
 
     if str(args.index) != "None":
-        subprocess.call(['STAR', '--genomeDir', str(args.index), '--runThreadN', '18', "--readFilesCommand", str("zcat"), \
+        subprocess.check_call(['STAR', '--genomeDir', str(args.index), '--runThreadN', '18', "--readFilesCommand", str("zcat"), \
         '--readFilesIn', str(mate1), str(mate2), '--outSAMtype', str("BAM"), str("SortedByCoordinate"), "--outFileNamePrefix", str(aln_dir + '/' + group + '_')], stdout=subprocess.DEVNULL)
     else:
-        subprocess.call(['STAR', '--genomeDir', str(out_dir + '/index'), '--runThreadN', '18', "--readFilesCommand", str("zcat"), \
+        subprocess.check_call(['STAR', '--genomeDir', str(out_dir + '/index'), '--runThreadN', '18', "--readFilesCommand", str("zcat"), \
         '--readFilesIn', str(mate1), str(mate2), '--outSAMtype', str("BAM"), str("SortedByCoordinate"), "--outFileNamePrefix", str(aln_dir + '/' + group + '_')], stdout=subprocess.DEVNULL)
 
 

--- a/scripts/mode1_prep_data.py
+++ b/scripts/mode1_prep_data.py
@@ -99,7 +99,7 @@ def annotation_manager():
         print("Star index found! Be sure that it is not corrupted \n")
     else:
         print(f"{clock}\tCreating STAR index with {out_genome}")
-        subprocess.call(['STAR', '--runThreadN', str(args.threads), '--runMode', str("genomeGenerate"), "--genomeDir", str(f"{out_dir}/index"), \
+        subprocess.check_call(['STAR', '--runThreadN', str(args.threads), '--runMode', str("genomeGenerate"), "--genomeDir", str(f"{out_dir}/index"), \
         "--genomeFastaFiles", str(args.genome), "--sjdbGTFfile", str(f"{tmp}/gtf_file.gtf"), "--sjdbOverhang", str(99)], stdout=subprocess.DEVNULL)
         print(colored("Done!", "green", attrs=['bold']))
 


### PR DESCRIPTION
`subprocess.call` doesn't check process exit code. This leads to situations when if STAR exists with an error (e.g. when it's OOM killed), ChimeraTE continues execution as if nothing happened, finishing with cryptic errors like "genomeParameters.txt is missing" which complicates finding the original issue.

With this change ChimeraTE will fail if STAR fails.